### PR TITLE
New Features : RibbonPageCategory and RibbonPageGroup Visibility

### DIFF
--- a/CABDevExpress.ExtensionKit/CABDevExpress.ExtensionKit.csproj
+++ b/CABDevExpress.ExtensionKit/CABDevExpress.ExtensionKit.csproj
@@ -106,6 +106,7 @@
     <Compile Include="UIElements\RibbonAppMenuBottomPaneSimpleButtonUIAdapter.cs" />
     <Compile Include="UIElements\RibbonGalleryGroupUIAdapter.cs" />
     <Compile Include="UIElements\RibbonGalleryUIAdapter.cs" />
+    <Compile Include="UIElements\RibbonPageCategoryCollectionUIAdapter.cs" />
     <Compile Include="UIElements\XtraAccordionControlUIAdapterFactory.cs" />
     <Compile Include="Workspaces\XtraTabbedMdiWorkspace.cs">
     </Compile>

--- a/CABDevExpress.ExtensionKit/Commands/RibbonPageGroupCommandAdapter.cs
+++ b/CABDevExpress.ExtensionKit/Commands/RibbonPageGroupCommandAdapter.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using DevExpress.Utils.Menu;
 using DevExpress.XtraBars.Ribbon;
 using Microsoft.Practices.CompositeUI.Commands;
@@ -19,7 +20,21 @@ namespace CABDevExpress.Commands
         /// Initializes  a new <see cref="RibbonPageGroupCommandAdapter"/> with the 
         /// given <see cref="DXMenuItem"/>.
         /// </summary>
-        public RibbonPageGroupCommandAdapter(RibbonPageGroup item, string eventName): base(item, eventName)
-        { }
+        public RibbonPageGroupCommandAdapter(RibbonPageGroup item, string eventName): base(item, eventName){ }
+
+        /// <summary>
+        /// Handles the changes in the <see cref="Command"/> by refreshing 
+        /// the <see cref="RepositoryItem.Enabled"/> property.
+        /// </summary>
+        protected override void OnCommandChanged(Command command)
+        {
+            base.OnCommandChanged(command);
+
+            foreach (KeyValuePair<RibbonPageGroup, List<string>> pair in Invokers)
+            {
+                pair.Key.Enabled = (command.Status == CommandStatus.Enabled);
+                pair.Key.Visible = (command.Status != CommandStatus.Unavailable);
+            }
+        }
     }
 }

--- a/CABDevExpress.ExtensionKit/UIElements/RibbonPageCategoryCollectionUIAdapter.cs
+++ b/CABDevExpress.ExtensionKit/UIElements/RibbonPageCategoryCollectionUIAdapter.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using DevExpress.Utils;
+using DevExpress.XtraBars.Ribbon;
+using Microsoft.Practices.CompositeUI.UIElements;
+
+namespace CABDevExpress.UIElements
+{
+    /// <summary>
+    /// Ribbon Page Category UI Adapter
+    /// </summary>
+    public class RibbonPageCategoryCollectionUIAdapter : UIElementAdapter<RibbonPageCategory>
+    {
+        private readonly RibbonPageCategoryCollection ribbonPageCategoryCollection;
+
+        public RibbonPageCategoryCollectionUIAdapter( RibbonPageCategoryCollection ribbonPageCategoryCollection)
+        {
+            Guard.ArgumentNotNull(ribbonPageCategoryCollection, "RibbonPageCategoryCollection");
+            this.ribbonPageCategoryCollection = ribbonPageCategoryCollection;
+        }
+        
+        protected override RibbonPageCategory Add(RibbonPageCategory uiElement)
+        {
+            Guard.ArgumentNotNull(uiElement, "RibbonPage");
+            ribbonPageCategoryCollection.Insert(GetInsertingIndex(uiElement), uiElement);
+            return uiElement;
+
+        }
+
+        protected override void Remove(RibbonPageCategory uiElement)
+        {
+            Guard.ArgumentNotNull(uiElement, "RibbonPageCategory");
+
+            if (uiElement.Ribbon != null)
+                ribbonPageCategoryCollection.Remove(uiElement);
+        }
+
+        /// <summary>
+		/// When overridden in a derived class, returns the correct index for the item being added. By default,
+		/// it will return the length of the ribbonPageCollection.
+		/// </summary>
+		/// <param name="uiElement"></param>
+		/// <returns></returns>
+		protected virtual int GetInsertingIndex(object uiElement)
+        {
+            return ribbonPageCategoryCollection.Count;
+        }
+    }
+}

--- a/CABDevExpress.ExtensionKit/UIElements/RibbonUIAdapterFactory.cs
+++ b/CABDevExpress.ExtensionKit/UIElements/RibbonUIAdapterFactory.cs
@@ -32,11 +32,17 @@ namespace CABDevExpress.UIElements
 			if (uiElement is RibbonPageCollection)
 				return new RibbonPageCollectionUIAdapter(((RibbonPageCollection)uiElement));
 
-			if (uiElement is BarItemWrapper)
-				return new BarLinksOwnerCollectionUIAdapter(((BarItemWrapper) uiElement).Item,
-				                                            ((BarItemWrapper) uiElement).ItemLinks);
+            if (uiElement is RibbonPageCategoryCollection)
+                return new RibbonPageCategoryCollectionUIAdapter((RibbonPageCategoryCollection)uiElement);
 
-			if (uiElement is RibbonQuickAccessToolbar)
+			if (uiElement is RibbonPageCategory)
+				return new RibbonPageCollectionUIAdapter(((RibbonPageCategory)uiElement).Pages);
+
+			if (uiElement is BarItemWrapper)
+                return new BarLinksOwnerCollectionUIAdapter(((BarItemWrapper)uiElement).Item,
+                                                            ((BarItemWrapper)uiElement).ItemLinks);
+
+            if (uiElement is RibbonQuickAccessToolbar)
 				return new RibbonQuickAccessToolbarUIAdapter((RibbonQuickAccessToolbar) uiElement);
 
 			if (uiElement is RibbonStatusBar)
@@ -63,7 +69,9 @@ namespace CABDevExpress.UIElements
 			       uiElement is RibbonPageCollection ||
 			       uiElement is BarItemWrapper ||
 			       uiElement is RibbonQuickAccessToolbar ||
-			       uiElement is RibbonStatusBar;
+			       uiElement is RibbonStatusBar ||
+                   uiElement is RibbonPageCategoryCollection ||
+				   uiElement is RibbonPageCategory;
 		}
 	}
 }

--- a/CABDevExpress.ExtensionKit/XtraFormApplicationBase.cs
+++ b/CABDevExpress.ExtensionKit/XtraFormApplicationBase.cs
@@ -2,6 +2,7 @@ using CABDevExpress.Commands;
 using CABDevExpress.UIElements;
 using DevExpress.Utils.Menu;
 using DevExpress.XtraBars;
+using DevExpress.XtraBars.Ribbon;
 using DevExpress.XtraEditors.Repository;
 using DevExpress.XtraNavBar;
 using Microsoft.Practices.CompositeUI;
@@ -36,6 +37,7 @@ namespace CABDevExpress
             mapService.Register(typeof(NavBarItem), typeof(NavBarItemCommandAdapter));
             mapService.Register(typeof(DXMenuItem), typeof(DXMenuItemCommandAdapter));
             mapService.Register(typeof(RepositoryItemHyperLinkEdit), typeof(RepositoryItemHyperLinkEditCommandAdapter));
+            mapService.Register(typeof(RibbonPageGroup), typeof(RibbonPageGroupCommandAdapter));
         }
 
         private void RegisterUIElementAdapterFactories()


### PR DESCRIPTION
Override function OnCommandChanged(Command command) on RibbonPageGroupCommandAdapter. You can yet add an Invoker on RibbonPageGroup CaptionButtonClick event and Manage his visibility with the CAB command.

Add RibbonPageCategory as UIElement. You can register RibbonPageCategory and target the category for a specified RibbonPage.